### PR TITLE
Update wdio.conf.js

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -83,19 +83,17 @@ exports.config = {
     // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
     // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
     // gets prepended directly.
-    baseUrl: 'http://localhost',
+    hostname: '127.0.0.1',
     port: 4723,
-    path: '/wd/hub',
+    path: '/',
 
     capabilities: [{
-        browserName: 'chrome',
-        "appium:platformName": "Android",
+        "platformName": "Android",
         "appium:platformVersion": "9.0",
         "appium:deviceName": "Ebac",
         "appium:automationName": "UiAutomator2",
         "appium:appPackage": "com.wdiodemoapp",
-        "appium:appWaitActivity": ".MainActivity",
-        "appium:appActivity": ".SplashActivity"
+        "appium:appWaitActivity": "MainActivity"
     }],
 
     //


### PR DESCRIPTION
Mexi em poucas coisas. Você deve estar com o `appium` instalado globalmente, por isso não consegui ver a versão (mas assumo que seja a 2). Por isso mexi no `path`, que não é `/wd/hub`, mas sim `/`; além disso, não usamos `browser` pra testar mobile, mas usamos o `driver`. Não é necessário definir o `browser` nas _capabilities_, então removi; o nome da chave associada ao `localhost` é `hostname`, não `baseUrl`; seu `appium:appWaitActivity` tinha um `.` desnecessário; a cap `appium:appActivity` não é necessária nesse caso porque você está usando uma cap pra esperar (`appium:appWaitActivity`).

Certifique-se que seu emulador se chama `Ebac` e está na versão `9.0`, porque não vai funcionar se estiver incompatível com o seu emulador.